### PR TITLE
Changed loading detail with head flag to true at view editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Fixed
  * Removed underlining of text in the state element
+ * Changed loading detail with head flag to true at view editing.
 
 ## [1.1.2-beta.2] - 2024-09-26
 ### Added

--- a/addon/objects/fd-view-attributes-detail.js
+++ b/addon/objects/fd-view-attributes-detail.js
@@ -26,5 +26,5 @@ export default FdViewAttributesProperty.extend({
     @property loadOnLoadAgregator
     @type Boolean
   */
-  loadOnLoadAgregator: false,
+  loadOnLoadAgregator: true,
 });


### PR DESCRIPTION
related to: https://gitlab.neoplatform.ru/flexberry-developers-tools/flexberry-designer/enterprise/designer.enterprise.backend/-/issues/243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Теперь данные отображаются автоматически при открытии детального просмотра атрибутов, что обеспечивает более оперативный доступ к информации.
  
- **Исправления ошибок**
  - Изменено поведение загрузки данных при редактировании представления: флаг загрузки теперь установлен в true.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->