### PR TITLE
Fixed issue with selecting the same stereotype twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
  * Removed underlining of text in the state element
  * Changed loading detail with head flag to true at view editing.
+ * Fixed selecting the same stereotype twice
 
 ## [1.1.2-beta.2] - 2024-09-26
 ### Added

--- a/addon/mixins/fd-popup-actions.js
+++ b/addon/mixins/fd-popup-actions.js
@@ -82,7 +82,8 @@ export default Mixin.create({
       popup.removeClass('visible');
       popup.addClass('hidden');
 
-      this.set('popupValue', undefined);
+      let selectedValue = $(popup).find('.flexberry-dropdown.selection');
+      selectedValue.dropdown('clear');
 
       $(document).off(`mousedown.${popupNamespace}`);
       $('.fd-sheet-body').off(`scroll.${popupNamespace}`);


### PR DESCRIPTION
[Issue 239](https://gitlab.neoplatform.ru/flexberry-developers-tools/flexberry-designer/enterprise/designer.enterprise.backend/-/issues/239)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - При закрытии всплывающих окон изменено поведение: выбранное значение в выпадающих списках теперь автоматически сбрасывается, что обеспечивает более корректное восстановление состояния интерфейса.
  
- **Bug Fixes**
  - Добавлено исправление в журнал изменений, касающееся проблемы с выбором одного и того же стереотипа дважды, что улучшает понимание обновлений пользователями.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->