### PR TITLE
Fix diagram saving by clear primitive refs in 'root.empty' state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Fixed
 * Fixed "Element is no longer attached to DOM" error
+* Fixed diagram saving where primitive references could remain in `root.empty` state
 
 ### Added
 * Added the stage ID to queryParams when navigating between sitemap items.

--- a/addon/components/fd-sheets/fd-diagram-sheet.js
+++ b/addon/components/fd-sheets/fd-diagram-sheet.js
@@ -403,10 +403,10 @@ export default FdBaseSheet.extend(
       });
 
       model.rollbackAll();
-      this.get('decrementedReferenceCountItems').clear();
       set(selectedValue, 'active', false);
     }
 
+    this.get('decrementedReferenceCountItems').clear();
     this.set('isDiagramVisible', false);
   },
 


### PR DESCRIPTION
https://gitlab.neoplatform.ru/flexberry-developers-tools/flexberry-designer/enterprise/designer.enterprise.backend/-/issues/245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления

* Исправлена ошибка при сохранении диаграмм, при которой примитивные ссылки могли оставаться в некорректном состоянии. Теперь данные правильно очищаются при завершении операции.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->