### PR TITLE
Add interface attr in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 * Fixed "Element is no longer attached to DOM" error
 * Fixed diagram saving where primitive references could remain in `root.empty` state
 * Fixed link highlight not following during drag in diagrams.
+* Add interface attr in view.
 
 ## [1.1.2-beta.6] - 2025-02-04
 ### Changed

--- a/addon/utils/fd-attributes-for-tree.js
+++ b/addon/utils/fd-attributes-for-tree.js
@@ -39,7 +39,7 @@ let getDataForBuildTree = function(store, id) {
       for (let i = 0; i < inheritanceData.length; i++) {
         let inheritance = inheritanceData[i];
         let parentStereotype = inheritance.get('parent.stereotype');
-        if (isNone(parentStereotype) || parentStereotype === '«implementation»') {
+        if (isNone(parentStereotype) || parentStereotype === '«implementation»'|| parentStereotype === '«interface»') {
           parentID = inheritance.get('parent.id');
           classData.pushObject(recordsDevClass.findBy('id', parentID));
           associationData.pushObjects(recordsAssociation.filterBy('endClass.id', parentID));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления
* Интерфейсы теперь корректно распознаются как допустимые родительские элементы при обходе иерархии наследования и включаются в данные родительского класса вместе с соответствующими связями.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->